### PR TITLE
Fix error Datafgrame object has no aatribute concat error

### DIFF
--- a/OMIEData/DataImport/omie_data_importer_from_responses.py
+++ b/OMIEData/DataImport/omie_data_importer_from_responses.py
@@ -26,7 +26,7 @@ class OMIEDataImporterFromResponses(OMIEDataImporter):
                                                           date_end=self.date_end,
                                                           verbose=verbose):
             try:
-                df = pd.concat([df, self.fileReader.get_data_from_response(response=response)], ignore_index=True)
+                df = pd.concat([df, self.fileReader.get_data_from_response(response=response)],ignore_index=True)
 
             except Exception as exc:
                 print('There was error processing file: ' + response.url)


### PR DESCRIPTION
I modified the omie_data_importer_from_responses.py code to avoid the "DataFrame' object has no attribute 'concat'" error when execute the examples.
Create after this issue: https://github.com/acruzgarcia/OMIEData/issues/8