### PR TITLE
Make localized decimal number parsing platform independent

### DIFF
--- a/OMIEData/FileReaders/adjustment_price_file_reader.py
+++ b/OMIEData/FileReaders/adjustment_price_file_reader.py
@@ -1,5 +1,5 @@
 import datetime as dt
-import locale
+from babel.numbers import parse_decimal
 import re
 import numpy as np
 import pandas as pd
@@ -161,14 +161,11 @@ class AdjustmentPriceFileReader(OMIEFileReader):
         result[key_list[0]] = date
         result[key_list[1]] = str(concept)
 
-        # These are the correct setting to read the files...
-        locale.setlocale(locale.LC_NUMERIC, AdjustmentPriceFileReader.__localeInFile__)
-
         for i, v in enumerate(values, start=1):
             if i > 25:
                 break  # Jump if 25-hour day or spaces ..
             try:
-                f = multiplier * locale.atof(v)
+                f = multiplier * float(parse_decimal(v, locale=self.__localeInFile__))
             except:
                 if i == 24:
                     # Day with 23-hours.

--- a/OMIEData/FileReaders/energy_by_technology_files_reader.py
+++ b/OMIEData/FileReaders/energy_by_technology_files_reader.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import locale
 from requests import Response
 from io import BytesIO
 
@@ -35,18 +34,12 @@ class EnergyByTechnologyHourlyFileReader(OMIEFileReader):
         return key_list_retrieve
 
     def get_data_from_response(self, response: Response) -> pd.DataFrame:
-
-        locale.setlocale(locale.LC_NUMERIC, "en_DK.UTF-8")
         return self._get_data_from_file_like(file_like=BytesIO(response.content))
 
     def get_data_from_file(self, filename: str) -> pd.DataFrame:
-
-        locale.setlocale(locale.LC_NUMERIC, "en_DK.UTF-8")
         return self._get_data_from_file_like(file_like=filename)
 
     def _get_data_from_file_like(self, file_like) -> pd.DataFrame:
-
-        locale.setlocale(locale.LC_NUMERIC, "en_DK.UTF-8")
         df = pd.read_csv(file_like, sep=';', skiprows=2, header=0, encoding='latin-1', skipfooter=1, engine='python',
                          decimal=",", thousands='.')
         df = df.rename({k: v for k, v in self._dict_column_concept.items()}, axis=1)

--- a/OMIEData/FileReaders/marginal_price_file_reader.py
+++ b/OMIEData/FileReaders/marginal_price_file_reader.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import re
-import locale
+from babel.numbers import parse_decimal
 import pandas as pd
 import numpy as np
 
@@ -121,15 +121,12 @@ class MarginalPriceFileReader(OMIEFileReader):
         result[key_list[0]] = date
         result[key_list[1]] = str(concept)
 
-        # These are the correct setting to read the files...
-        locale.setlocale(locale.LC_NUMERIC, MarginalPriceFileReader.__localeInFile__)
-
         for i, v in enumerate(values, start=1):
 
             if i > 25:
                 break # Jump if 25-hour day or spaces ..
             try:
-                f = multiplier * locale.atof(v)
+                f = multiplier * float(parse_decimal(v, locale=self.__localeInFile__))
             except:
 
                 if i == 24:

--- a/OMIEData/FileReaders/supply_demand_curve_file_reader.py
+++ b/OMIEData/FileReaders/supply_demand_curve_file_reader.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import locale
 from requests import Response
 from io import BytesIO
 
@@ -23,18 +22,12 @@ class SupplyDemandCurvesReader(OMIEFileReader):
         return list(self._dict_column_concept.values())
 
     def get_data_from_response(self, response: Response) -> pd.DataFrame:
-
-        locale.setlocale(locale.LC_NUMERIC, "en_DK.UTF-8")
         return self._get_data_from_file_like(file_like=BytesIO(response.content))
 
     def get_data_from_file(self, filename: str) -> pd.DataFrame:
-
-        locale.setlocale(locale.LC_NUMERIC, "en_DK.UTF-8")
         return self._get_data_from_file_like(file_like=filename)
 
     def _get_data_from_file_like(self, file_like) -> pd.DataFrame:
-
-        locale.setlocale(locale.LC_NUMERIC, "en_DK.UTF-8")
         df = pd.read_csv(file_like, sep=';', skiprows=2, header=0, encoding='latin-1', skipfooter=1, engine='python',
                          decimal=",", thousands='.')
         df = df.rename({k: v for k, v in self._dict_column_concept.items()}, axis=1)

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.10",
     keywords=["OMIE", "Electricity prices"],
-    install_requires=["pandas>=2.0.1", "requests", "datetime"],
+    install_requires=["pandas>=2.0.1", "requests", "datetime", "babel"],
 )


### PR DESCRIPTION
Currently, the parsing of localized numbers (basically decimal numbers using a comma to represent the decimal point) is done with `locale.setlocale` and the locale `en_DK.UTF-8`, the issue with this locale is that it's not available by default on non-Windows platform (Linux and Mac OS).

This change uses a different approach with the `babel` package to handle the number parsing so that this package is usable out of the box on every platform. These changes were tested on Mac OS.

Related issues:
https://github.com/acruzgarcia/OMIEData/issues/2
https://github.com/acruzgarcia/OMIEData/issues/6